### PR TITLE
Don't log an exception when cancelling the MulticastClient

### DIFF
--- a/src/Mdns/MulticastClient.cs
+++ b/src/Mdns/MulticastClient.cs
@@ -152,6 +152,10 @@ internal class MulticastClient : IDisposable
                 }
             }
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            //Ignore
+        }
         catch (Exception ex)
         {
             _logger?.ReceiverFailure(ex);


### PR DESCRIPTION
ReceiveAsync throws when the cancellationToken is cancelled.
As this is expected behaviour - don't log this as ReceiverFailure.

(Also thanks for resurrecting/updating this library!)